### PR TITLE
Add motd

### DIFF
--- a/hasselhoff.sh
+++ b/hasselhoff.sh
@@ -18,5 +18,8 @@ BINDIR="/tmp/david"
 mkdir -m a=rwx -p $BINDIR
 cd $BINDIR && curl -s -L $AMD64_URL -O
 chmod u=rwx $BINDIR/hasselhoffme_${VERSION}_${machine}_amd64
-$BINDIR/hasselhoffme_${VERSION}_${machine}_amd64
-sudo $BINDIR/hasselhoffme_${VERSION}_${machine}_amd64 setmotd
+if [ -z "$DISPLAY" ] && [ "$machine" != "darwin" ];then
+    sudo $BINDIR/hasselhoffme_${VERSION}_${machine}_amd64 setmotd
+else
+    $BINDIR/hasselhoffme_${VERSION}_${machine}_amd64
+fi

--- a/hasselhoff.sh
+++ b/hasselhoff.sh
@@ -12,10 +12,11 @@ case "${platform}" in
     MINGW*)     machine=MinGw;;
     *)          machine="UNKNOWN:${platform}"
 esac
-VERSION="0.1.0"
+VERSION="0.2.0"
 AMD64_URL="https://github.com/angelbarrera92/hasselhoffme/releases/download/${VERSION}/hasselhoffme_${VERSION}_${machine}_amd64"
 BINDIR="/tmp/david"
 mkdir -m a=rwx -p $BINDIR
 cd $BINDIR && curl -s -L $AMD64_URL -O
 chmod u=rwx $BINDIR/hasselhoffme_${VERSION}_${machine}_amd64
 $BINDIR/hasselhoffme_${VERSION}_${machine}_amd64
+sudo $BINDIR/hasselhoffme_${VERSION}_${machine}_amd64 setmotd

--- a/hasselhoffme.go
+++ b/hasselhoffme.go
@@ -2,15 +2,19 @@ package main
 
 import (
 	"fmt"
+	"io/ioutil"
 	"net/http"
 	"os"
+	"regexp"
 
 	"github.com/angelbarrera92/hasselhoffme/images"
 	"github.com/reujab/wallpaper"
 	"github.com/zyxar/image2ascii/ascii"
 )
 
-const MOTD_FILE = "/etc/update-motd.d/99-hasselhoffme"
+const MOTD_FILE = "/etc/motd"
+const UPDATE_MOTD_PATH = "/etc/update-motd.d"
+const UPDATE_MOTD_FILE = UPDATE_MOTD_PATH + "/99-hasselhoffme"
 
 func usage() {
 	fmt.Fprintf(os.Stderr, `%s [-h] [<action>]
@@ -70,9 +74,43 @@ func setMotdFromURL(url string) {
 		Flipy:  false}
 	motd, err := ascii.Decode(resp.Body, opt)
 
+	if _, err := os.Stat(UPDATE_MOTD_PATH); os.IsNotExist(err) {
+		writeMotd(motd)
+	} else {
+		writeUpdateMotdScript(motd)
+	}
+}
+
+func writeMotd(motd *ascii.Ascii) {
+	content := ""
+	if _, err := os.Stat(MOTD_FILE); !os.IsNotExist(err) {
+		content_bytes, err := ioutil.ReadFile(MOTD_FILE)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "error while opening %s: %v\n", MOTD_FILE, err)
+			os.Exit(1)
+		}
+		content = string(content_bytes)
+	}
+
+	re := regexp.MustCompile(`(?s)### hasselhon ###.*### hasselhoff ###`)
+	content = re.ReplaceAllString(content, "")
+
 	f, err := os.OpenFile(MOTD_FILE, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error while opening %s: %v\n", MOTD_FILE, err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, "%s### hasselhon ###\n", content)
+	motd.WriteTo(f)
+	fmt.Fprintf(f, "### hasselhoff ###")
+}
+
+func writeUpdateMotdScript(motd *ascii.Ascii) {
+	f, err := os.OpenFile(UPDATE_MOTD_FILE, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error while opening %s: %v\n", UPDATE_MOTD_FILE, err)
 		os.Exit(1)
 	}
 	defer f.Close()
@@ -83,5 +121,4 @@ cat <<EOF
 
 	motd.WriteTo(f)
 	fmt.Fprintf(f, "EOF\n")
-
 }

--- a/hasselhoffme.go
+++ b/hasselhoffme.go
@@ -92,7 +92,7 @@ func writeMotd(motd *ascii.Ascii) {
 		content = string(content_bytes)
 	}
 
-	re := regexp.MustCompile(`(?s)### hasselhon ###.*### hasselhoff ###`)
+	re := regexp.MustCompile(`(?s)### hasselhon ###.*### hasselhoff ###\n`)
 	content = re.ReplaceAllString(content, "")
 
 	f, err := os.OpenFile(MOTD_FILE, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
@@ -104,7 +104,7 @@ func writeMotd(motd *ascii.Ascii) {
 
 	fmt.Fprintf(f, "%s### hasselhon ###\n", content)
 	motd.WriteTo(f)
-	fmt.Fprintf(f, "### hasselhoff ###")
+	fmt.Fprintf(f, "### hasselhoff ###\n")
 }
 
 func writeUpdateMotdScript(motd *ascii.Ascii) {

--- a/hasselhoffme.go
+++ b/hasselhoffme.go
@@ -70,7 +70,7 @@ func setMotdFromURL(url string) {
 		Flipy:  false}
 	motd, err := ascii.Decode(resp.Body, opt)
 
-	f, err := os.OpenFile(MOTD_FILE, os.O_RDWR|os.O_CREATE, 0755)
+	f, err := os.OpenFile(MOTD_FILE, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0755)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "error while opening %s: %v\n", MOTD_FILE, err)
 		os.Exit(1)

--- a/hasselhoffme.go
+++ b/hasselhoffme.go
@@ -1,14 +1,43 @@
 package main
 
 import (
-	"github.com/reujab/wallpaper"
+	"fmt"
+	"net/http"
+	"os"
+
 	"github.com/angelbarrera92/hasselhoffme/images"
+	"github.com/reujab/wallpaper"
+	"github.com/zyxar/image2ascii/ascii"
 )
 
+const MOTD_FILE = "/etc/update-motd.d/99-hasselhoffme"
+
+func usage() {
+	fmt.Fprintf(os.Stderr, `%s [-h] [<action>]
+  available actions:
+	setwallpaper: sets a random wallpaper
+			(default if no action specified)
+	setmotd: sets a random ascii art motd
+`, os.Args[0])
+	os.Exit(1)
+}
+
 func main() {
+	action := "setwallpaper"
 	url := SearchRandomImage(images.SearchGithubRawImages, "")
 
-	setWallpaperFromURL(url)
+	if len(os.Args) >= 2 {
+		action = os.Args[1]
+	}
+
+	switch action {
+	case "setwallpaper":
+		setWallpaperFromURL(url)
+	case "setmotd":
+		setMotdFromURL(url)
+	default:
+		usage()
+	}
 }
 
 func SearchRandomImage(sifn images.SearchImageFn, wordsToSearch string) string {
@@ -19,3 +48,40 @@ func setWallpaperFromURL(url string) {
 	wallpaper.SetFromURL(url)
 }
 
+func setMotdFromURL(url string) {
+	if os.Getuid() != 0 {
+		fmt.Fprintf(os.Stderr, "motd can only be changed as root\n")
+		os.Exit(1)
+	}
+
+	resp, err := http.Get(url)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error while downloading %s: %v\n", url, err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+
+	opt := ascii.Options{
+		Width:  0,
+		Height: 0,
+		Color:  false,
+		Invert: false,
+		Flipx:  false,
+		Flipy:  false}
+	motd, err := ascii.Decode(resp.Body, opt)
+
+	f, err := os.OpenFile(MOTD_FILE, os.O_RDWR|os.O_CREATE, 0755)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error while opening %s: %v\n", MOTD_FILE, err)
+		os.Exit(1)
+	}
+	defer f.Close()
+
+	fmt.Fprintf(f, `#!/bin/sh
+cat <<EOF
+`)
+
+	motd.WriteTo(f)
+	fmt.Fprintf(f, "EOF\n")
+
+}


### PR DESCRIPTION
This PR fixes #15 

Usage:
`sudo hasselhoffme setmotd`


NB:
The motd should be managed by update-motd, and can be tested manually by running `run-parts /etc/update-motd.d`
The shellscript expects a release version of 0.2.0 to change both wallpaper and motd
