### PR TITLE
PR to address project linting issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,43 @@
+.PHONY: test lint check cover
+.PHONY: install-linters
+#.PHONY: release
+
+test: ## Run tests
+	go test -race ./... -timeout=5m
+
+lint: ## Run linters. Use make install-linters first.
+	vendorcheck ./...
+	$(GOPATH)/bin/golangci-lint run --no-config --deadline=3m --disable-all --tests \
+		-E golint \
+		-E goimports \
+		-E varcheck \
+		-E unparam \
+		-E deadcode \
+		-E structcheck \
+		-E errcheck \
+		-E gosimple \
+		-E staticcheck \
+		-E unused \
+		-E ineffassign \
+		-E typecheck \
+		-E gas \
+		-E megacheck \
+		-E misspell \
+		./...
+	# The govet version in golangci-lint is out of date and has spurious warnings, run it separately
+	#go vet -all ./...
+
+check: lint test  ## Run tests and linters
+
+cover: ## Runs tests on ./cmd/ with HTML code coverage
+	go test -race -cover -coverprofile=cover.out -coverpkg=github.com/angelbarrera92/hasselhoffme/... ./...
+	go tool cover -html=cover.out
+
+install-linters: ## Install linters
+	go get -u github.com/FiloSottile/vendorcheck
+	# Pin to v1.10.2
+	curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $(GOPATH)/bin v1.10.2
+
+## TODO: Add support for goreleaser
+#release: check	## Use GoReleaser to build, package and release
+#	goreleaser --rm-dist

--- a/images/bing_images.go
+++ b/images/bing_images.go
@@ -1,18 +1,20 @@
 package images
 
 import (
-	"net/http"
 	"fmt"
 	"io/ioutil"
-	"strings"
-	"golang.org/x/net/html"
+	"net/http"
 	url2 "net/url"
+	"strings"
+
+	"golang.org/x/net/html"
 )
 
-const BaseUrl = "http://www.bing.com/images/search?q="
+const BaseURL = "http://www.bing.com/images/search?q="
 
 func SearchBingImage(searchWord string) (result string) {
-	images, err := parseResult(searchWord); if err != nil {
+	images, err := parseResult(searchWord)
+	if err != nil {
 		return err.Error()
 	}
 
@@ -22,26 +24,28 @@ func SearchBingImage(searchWord string) (result string) {
 }
 
 func parseResult(searchWord string) (results []ImageResult, err error) {
-	url := BaseUrl + url2.QueryEscape(searchWord)
+	url := BaseURL + url2.QueryEscape(searchWord)
 
-	resp, err := http.Get(url); if err != nil {
+	resp, err := http.Get(url)
+	if err != nil {
 		return nil, err
 	} else if resp.StatusCode > 203 {
 		return nil, fmt.Errorf("response code %d", resp.StatusCode)
 	}
 
-	page, err := ioutil.ReadAll(resp.Body); if err != nil {
+	page, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
 		return nil, err
 	}
 
 	defer resp.Body.Close()
 
-	bodyHtml := strings.Replace(string(page), "<noscript>", "", -1)
-	bodyHtml = strings.Replace(bodyHtml, "</noscript>", "", -1)
+	bodyHTML := strings.Replace(string(page), "<noscript>", "", -1)
+	bodyHTML = strings.Replace(bodyHTML, "</noscript>", "", -1)
 
 	var images []ImageResult
 
-	if document, err := html.Parse(strings.NewReader(bodyHtml)); err == nil {
+	if document, err := html.Parse(strings.NewReader(bodyHTML)); err == nil {
 
 		var parser func(node *html.Node)
 
@@ -55,7 +59,7 @@ func parseResult(searchWord string) (results []ImageResult, err error) {
 							Source: e.Val,
 							Index:  c,
 						})
-						c ++
+						c++
 					}
 				}
 			}

--- a/images/gitraw_images.go
+++ b/images/gitraw_images.go
@@ -1,31 +1,31 @@
 package images
 
 import (
-	"fmt"
-	"net/http"
 	"encoding/json"
+	"fmt"
 	"io/ioutil"
+	"net/http"
 )
 
 const UserRepo = "angelbarrera92/hasselhoffme"
 
 type Links struct {
 	Self string `json:"message"`
-	Git string `json:"git"`
-	Html string `json:"html"`
+	Git  string `json:"git"`
+	HTML string `json:"html"` // nolint
 }
 
 type Content struct {
-	Name string `json:"name"`
-	Path string `json:"path"`
-	Sha string `json:"sha"`
-	Size int `json:"size"`
-	Url string `json:"url"`
-	HtmlUrl string `json:"html_url"`
-	GitUrl string `json:"git_url"`
-	DownloadUrl string `json:"download_url"`
-	TypeObject string `json:"type"`
-	Links Links `json:"links"`
+	Name        string `json:"name"`
+	Path        string `json:"path"`
+	Sha         string `json:"sha"`
+	Size        int    `json:"size"`
+	URL         string `json:"url"`
+	HtmlURL     string `json:"html_url"`     // nolint
+	GitURL      string `json:"git_url"`      // nolint
+	DownloadURL string `json:"download_url"` // nolint
+	TypeObject  string `json:"type"`
+	Links       Links  `json:"links"`
 }
 
 func SearchGithubRawImages(w string) (result string) {
@@ -40,8 +40,8 @@ func SearchGithubRawImages(w string) (result string) {
 
 	for k, v := range content {
 		images = append(images, ImageResult{
-			Source: v.DownloadUrl,
-			Index: k,
+			Source: v.DownloadURL,
+			Index:  k,
 		})
 	}
 
@@ -50,20 +50,23 @@ func SearchGithubRawImages(w string) (result string) {
 	return images[rn].Source
 }
 
-func getContent(baseUrl string) ([]Content, error) {
+func getContent(baseURL string) ([]Content, error) {
 
 	var content []Content
 
-	resp, _ := http.Get(baseUrl)
+	resp, err := http.Get(baseURL)
+	if err != nil {
+		return nil, err
+	}
 	if resp.StatusCode >= 400 {
 		return nil, fmt.Errorf("error response: %s", resp.Body)
 	}
 
 	defer resp.Body.Close()
 
-	body, err := ioutil.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
+	body, ioerr := ioutil.ReadAll(resp.Body)
+	if ioerr != nil {
+		return nil, ioerr
 	}
 
 	err = json.Unmarshal(body, &content)

--- a/images/search_images.go
+++ b/images/search_images.go
@@ -2,7 +2,7 @@ package images
 
 type ImageResult struct {
 	Source string
-	Index int
+	Index  int
 }
 
-type SearchImageFn func(w string) (string)
+type SearchImageFn func(w string) string

--- a/images/utils.go
+++ b/images/utils.go
@@ -1,22 +1,26 @@
 package images
 
 import (
-	"time"
 	"math/rand"
+	"time"
 )
 
 func initRand() {
 	rand.Seed(time.Now().Unix())
 }
 
+// RandomNumber returns a randomly selected integer constrained by the length of the
+// []ImageResult array passed to it
 func RandomNumber(images []ImageResult) int {
 	initRand()
 
 	return rand.Intn(len(images))
 }
 
+// RandomNumberInt returns a randomly generated integeger constrained by the
+// min and max int values passed to it.
 func RandomNumberInt(min int, max int) int {
 	initRand()
 
-	return rand.Intn(max - min) + min
+	return rand.Intn(max-min) + min
 }


### PR DESCRIPTION
Added Makefile with some simple targets:
- `test` which will run go tests
- `lint` which will run both `vendorcheck` and then `golangcli-lint` (metalinter)
- `check` which will run `lint` and then `test`
- `cover` which will run go test coverage
- `install-linters` will ensure both `vendorcheck` and `golangcli-lint` are installed
Have added a TODO item for `release` to support `goreleaser`

Addressed all locally reported linting issues (reported by `Make check`).
Note that several linting exceptions have been suppressed and will need further review. These can be identified by searching for the `nolint` comment block in the source.

Several linting errors were caused by not checking errors from function calls. These have been fixed, but may need to review to ensure the desired behavior has now been added.

This is an extension to issue #28 and builds on PR #32 